### PR TITLE
Major bugfix (correct codecs never applied)

### DIFF
--- a/src/PHPVideoToolkit/AudioFormat.php
+++ b/src/PHPVideoToolkit/AudioFormat.php
@@ -211,7 +211,7 @@
                 if($codecs_in_preference_order !== false){
                     $audio_codec = array_shift($codecs_in_preference_order);
                     while(in_array($audio_codec, $codecs) === false && count($codecs_in_preference_order) > 0){
-                        $audio_codec = array_shift($codecs_in_preference_order);
+                        array_push($codecs, $audio_codec);
                     }
                 }
             }


### PR DESCRIPTION
Correct audio codecs were never applied. For example, AudioFormat_Mkv sets audioCodec to libvorbis, but instead, setAudioCodec function instead sets codec as vorbis. Found the bug when working with mono files.
